### PR TITLE
fix: remove pytest from main group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1285,7 +1285,6 @@ files = [
     {file = "greenlet-3.0.0-cp39-cp39-win32.whl", hash = "sha256:0d3f83ffb18dc57243e0151331e3c383b05e5b6c5029ac29f754745c800f8ed9"},
     {file = "greenlet-3.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:831d6f35037cf18ca5e80a737a27d822d87cd922521d18ed3dbc8a6967be50ce"},
     {file = "greenlet-3.0.0-cp39-universal2-macosx_11_0_x86_64.whl", hash = "sha256:a048293392d4e058298710a54dfaefcefdf49d287cd33fb1f7d63d55426e4355"},
-    {file = "greenlet-3.0.0.tar.gz", hash = "sha256:19834e3f91f485442adc1ee440171ec5d9a4840a1f7bd5ed97833544719ce10b"},
 ]
 
 [package.extras]
@@ -3944,4 +3943,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "ece137a2b8a30bfa53620537175628a675756abcafe160d94e77071794a51b6b"
+content-hash = "7139ac256e5d8c64c9e9e8eabe7a6bef3792aa5bd4981a8def4e26414282ef63"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,20 +4,19 @@ version = "0.2.1"
 description = "The SDK for instrumenting applications for tracking AI costs."
 authors = ["Nebuly"]
 readme = "README.md"
-packages = [{include = "nebuly"}]
+packages = [{ include = "nebuly" }]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-pytest = "^7.4.2"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.7.0"
+pytest = "^7.4.2"
 pylint = "^2.17.5"
 ruff = "^0.0.287"
 mypy = "^1.5.1"
-pytest = "^7.4.1"
 hypothesis = "^6.84.0"
-openai = {extras = ["datalib"], version = "^0.28.0"}
+openai = { extras = ["datalib"], version = "^0.28.0" }
 isort = "^5.12.0"
 bandit = "^1.7.5"
 safety = "^2.3.5"
@@ -27,8 +26,8 @@ pytest-asyncio = "^0.21.1"
 google-cloud-aiplatform = "^1.33.1"
 cohere = "^4.27"
 anthropic = "^0.3.11"
-langchain = { version = "^0.0.306", python=">=3.8.1,<4.0"}
-google-generativeai = { version = "^0.2", python=">=3.9,<4.0"}
+langchain = { version = "^0.0.306", python = ">=3.8.1,<4.0" }
+google-generativeai = { version = "^0.2", python = ">=3.9,<4.0" }
 transformers = "^4.34.0"
 torch = "^1.13.1"
 boto3 = "^1.28.63"
@@ -40,12 +39,12 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pylint.messages_control]
 disable = [
-  "invalid-name",
-  "missing-class-docstring",
-  "missing-function-docstring",
-  "missing-module-docstring",
-  "too-few-public-methods",
-  "fixme",
+    "invalid-name",
+    "missing-class-docstring",
+    "missing-function-docstring",
+    "missing-module-docstring",
+    "too-few-public-methods",
+    "fixme",
 ]
 
 [tool.pylint.format]


### PR DESCRIPTION
This PR removes Pytest from the main dependencies group.

I've just noticed that all the other dependencies are under the group `dev`. Is this correct? Shouldn't we manage these dependencies as extras?